### PR TITLE
CW2-6 Dockerise Website

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git

--- a/Dockerfiles/.dev.Dockerfile
+++ b/Dockerfiles/.dev.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD npm run dev

--- a/Dockerfiles/.prod.Dockerfile
+++ b/Dockerfiles/.prod.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16-alpine
+RUN mkdir -p /app
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -5,5 +5,9 @@
 - Run using `npm run dev`
 
 ## How to run on docker
+Download Docker Desktop from [here](https://www.docker.com/products/docker-desktop/).
+Launch the Docker Desktop App.
+Install the Docker extension on Visual Studio Code.
+
 For a development environment run `docker-compose -f dev.docker-compose.yaml up`. This will reflect live code changes.
 For a production environment run `docker-compose -f prod.docker-compose.yaml up`. This builds the environment way done for production.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 ## How to run locally
 - Install dependencies with `npm install`
 - Run using `npm run dev`
+
+## How to run on docker
+For a development environment run `docker-compose -f dev.docker-compose.yaml up`. This will reflect live code changes.
+For a production environment run `docker-compose -f prod.docker-compose.yaml up`. This builds the environment way done for production.

--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.5'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./Dockerfiles/.dev.Dockerfile
+    container_name: docker-next
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/app
+      - /app/node_modules

--- a/prod.docker-compose.yaml
+++ b/prod.docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.5'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./Dockerfiles/.prod.Dockerfile
+    container_name: docker-next
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/app
+      - /app/node_modules


### PR DESCRIPTION
### Why the changes are required?
To allow the website to be dockerised
### Changes
- added dev and prod dockerfiles in a Dockerfiles folder
- Added a .dev.docker-compose.yaml file
- Added a .prod.docker-compose.yaml file
### Screenshots
None
### Comments
These containers can be run (when docker is running) with docker-compose -f prod.docker-compose.yaml up && docker-compose -f dev.docker-compose.yaml up
Not sure if we use ENV files for a statically deployed websites; so env files are not considered by each container
It is worth noting, that the site wouldn't build properly 