### PR TITLE
[CW2-36] Linking Merch Store Link in nav bar and hamburger

### DIFF
--- a/frontend/public/assets/merch-store-icon.svg
+++ b/frontend/public/assets/merch-store-icon.svg
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff">
+
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+
+<g id="SVGRepo_iconCarrier"> <path d="M6.29977 5H21L19 12H7.37671M20 16H8L6 3H3M9 20C9 20.5523 8.55228 21 8 21C7.44772 21 7 20.5523 7 20C7 19.4477 7.44772 19 8 19C8.55228 19 9 19.4477 9 20ZM20 20C20 20.5523 19.5523 21 19 21C18.4477 21 18 20.5523 18 20C18 19.4477 18.4477 19 19 19C19.5523 19 20 19.4477 20 20Z" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/> </g>
+
+</svg>

--- a/frontend/src/components/Hamburger.tsx
+++ b/frontend/src/components/Hamburger.tsx
@@ -51,7 +51,7 @@ export default function Hamburger() {
                 <Link href={'./contact-us'}>Contact Us</Link>
               </li>
               <li className="py-2 text-lg">
-                <a href="https://csesoc-merch.square.site/">Merch Store</a>
+                <a target="_blank" href="https://csesoc-merch.square.site/">Merch Store</a>
               </li>
             </ul>
           </motion.div>

--- a/frontend/src/components/Hamburger.tsx
+++ b/frontend/src/components/Hamburger.tsx
@@ -50,6 +50,9 @@ export default function Hamburger() {
               <li className="py-2 text-lg">
                 <Link href={'./contact-us'}>Contact Us</Link>
               </li>
+              <li className="py-2 text-lg">
+                <a href="https://csesoc-merch.square.site/">Merchandise</a>
+              </li>
             </ul>
           </motion.div>
         )}

--- a/frontend/src/components/Hamburger.tsx
+++ b/frontend/src/components/Hamburger.tsx
@@ -51,7 +51,7 @@ export default function Hamburger() {
                 <Link href={'./contact-us'}>Contact Us</Link>
               </li>
               <li className="py-2 text-lg">
-                <a href="https://csesoc-merch.square.site/">Merchandise</a>
+                <a href="https://csesoc-merch.square.site/">Merch Store</a>
               </li>
             </ul>
           </motion.div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -40,6 +40,16 @@ const Navbar = () => {
           <Link href="/contact-us">
             <div className="text-xl">{'//'} contact us</div>
           </Link>
+          <a href="https://csesoc-merch.square.site/" className='flex xl:gap-3 lg:gap-1.5 md:gap-0.8 duration-300 hover:scale-105'>
+            <div className="text-xl">{'//'} merch store</div>
+            <Image
+              src="/assets/merch-store-icon.svg"
+              alt="Merchandise Store Icon"
+              width={30}
+              height={30}
+              draggable={false}
+            />
+          </a>
         </div>
         <div className="md:hidden xl:hidden lg:hidden text-right font-bold block">
           <Hamburger />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -40,13 +40,12 @@ const Navbar = () => {
           <Link href="/contact-us">
             <div className="text-xl">{'//'} contact us</div>
           </Link>
-          <a href="https://csesoc-merch.square.site/" className='flex xl:gap-3 lg:gap-1.5 md:gap-0.8 duration-300 hover:scale-105'>
-            <div className="text-xl">{'//'} merch store</div>
+          <a target="_blank" href="https://csesoc-merch.square.site/" className='flex'>
             <Image
               src="/assets/merch-store-icon.svg"
               alt="Merchandise Store Icon"
-              width={30}
-              height={30}
+              width={29}
+              height={29}
               draggable={false}
             />
           </a>


### PR DESCRIPTION
Changes:
- Added merch store to nav bar and hamburger (can change text to just use icon)
- Added hover zoom effect for merch store (might want to remove or add for all nav bar elements)

<img width="934" alt="new navbar with merch" src="https://github.com/csesoc/csesoc-website-2023/assets/143063143/0e76083c-36e6-43e5-bbdf-a1540115fc8d">
<img width="440" alt="image" src="https://github.com/csesoc/csesoc-website-2023/assets/143063143/23db561b-79f4-4580-9717-d492e404069d">
